### PR TITLE
feature: Add support for page up/down keys in list views

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,8 @@ Playback control:
 List view:
  * `up arrow` - Move cursor up
  * `down arrow` - Move cursor down
+ * `Page Up` - Move cursor up by half page
+ * `Page Down` - Move cursor down by half page
  * `Home` - Move cursor to the first item
  * `End` - Move cursor to the last item
  * `insert` - Toggle selection

--- a/src/helpbrowser/helpbrowser.cpp
+++ b/src/helpbrowser/helpbrowser.cpp
@@ -45,6 +45,8 @@ HelpBrowser::HelpBrowser(const Rectangle& rect, Window *parent) :
     {
         {"Move cursor up",                       KeyEvent::KeyUp    },
         {"Move cursor down",                     KeyEvent::KeyDown  },
+        {"Move cursor up by half page",          KeyEvent::KeyPageUp},
+        {"Move cursor down by half page",        KeyEvent::KeyPageDown},
         {"Move cursor to the first item",        KeyEvent::KeyHome  },
         {"Move cursor to the last item",         KeyEvent::KeyEnd   },
         {"Toggle selection",                     KeyEvent::KeyInsert},

--- a/src/lib/listview.cpp
+++ b/src/lib/listview.cpp
@@ -502,6 +502,24 @@ void ListView::keyPressedEvent(const KeyEvent& keyEvent)
             d->cursorDown();
             break;
 
+        case KeyEvent::KeyPageUp:
+            if (d->currentItem != -1) {
+                int nc = d->currentItem - (lines() / 2);
+                if (nc < 0)
+                    nc = 0;
+                setCurrentItem(nc);
+            }
+            break;
+
+        case KeyEvent::KeyPageDown:
+            if (d->currentItem != -1) {
+                int nc = d->currentItem + (lines() / 2);
+                if (nc >= d->model->itemsCount())
+                    nc = d->model->itemsCount() - 1;
+                setCurrentItem(nc);
+            }
+            break;
+
         case KeyEvent::KeyEnter:
             if (d->currentItem != -1 && !d->currentItemHidden)
                 itemEntered(d->currentItem);


### PR DESCRIPTION
Patches that adds support for pgup/down keys in list views, moves cursor half of "page" e.g. current view size down/up in  the list.